### PR TITLE
Revamp event booking section with blocked-date availability calendar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,4 @@
-import logo from "./logo.svg";
 import "./App.css";
-import Header from "./Component/Header/Header";
 import Main from "./Pages/Main/Main";
 
 function App() {

--- a/src/Component/Banner/Banner.js
+++ b/src/Component/Banner/Banner.js
@@ -1,4 +1,4 @@
-import { Box, Typography, Grid } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 
 const Styles = {
   menusBox: {

--- a/src/Component/Booking/Booking.js
+++ b/src/Component/Booking/Booking.js
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import {
   Box,
   Typography,
@@ -6,122 +7,193 @@ import {
   Button,
   MenuItem,
   Select,
+  Chip,
+  Stack,
 } from "@mui/material";
-import { DatePicker } from "@mui/x-date-pickers";
-import { hover } from "@testing-library/user-event/dist/hover";
-import { useState } from "react";
+import CalendarMonthRoundedIcon from "@mui/icons-material/CalendarMonthRounded";
+import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+
+const WEEK_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const SAVED_EVENTS = [
+  { date: "2026-03-06", title: "Private Music Concert" },
+  { date: "2026-03-11", title: "Corporate Dinner Meetup" },
+  { date: "2026-03-18", title: "Wedding Celebration" },
+  { date: "2026-03-23", title: "Food Festival Booking" },
+  { date: "2026-04-04", title: "Birthday Theme Party" },
+];
 
 const Styles = {
   menusBox: {
-    padding: "0 60px",
-    marginTop: "60px",
+    px: { xs: 2.5, md: 7 },
+    mt: 7,
+    pb: 4,
   },
   menuHeading: {
-    marginBottom: "40px",
+    mb: 4,
     textAlign: "left",
-    fontSize: "35px",
-    fontWeight: 600,
+    fontSize: { xs: "30px", md: "36px" },
+    fontWeight: 700,
     fontFamily: "Inter",
   },
-  bannerImage: {
-    width: "100%",
+  bookingCard: {
+    boxShadow: "0px 12px 35px 0px #0000001f",
+    borderRadius: "18px",
+    p: { xs: 2.5, md: 4 },
+    background: "linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)",
   },
-  submitBtn: {
-    backgroundColor: "black",
-    padding: "12px 42px",
-    marginTop: "15px",
-    "&:hover": {
-      backgroundColor: "black",
-    },
-    alignSelf: "flex-start",
+  sectionTitle: {
+    fontSize: "20px",
+    fontWeight: 600,
+    textAlign: "left",
+    mb: 2,
   },
   inputStyle: {
-    width: "344px",
-    "& .MuiSelect-select": {
-      textAlign: "left",
+    width: "100%",
+    "& .MuiInputBase-root": {
+      borderRadius: "10px",
+      backgroundColor: "#ffffff",
     },
   },
-  inputBox: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start",
-    gap: "10px",
+  label: {
+    fontSize: "14px",
+    fontWeight: 600,
+    color: "#1f2937",
+    textAlign: "left",
   },
-  inputGroup: {
-    display: "flex",
-    justifyContent: "flex-start",
-    gap: "30px",
-    flexWrap: "wrap",
-  },
-  bookingForm: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    gap: "30px",
-  },
-  inputName: {
-    fontSize: "20px",
-    fontWeight: 500,
-    fontFamily: "Inter",
-  },
-  booktableBox: {
-    boxShadow: "0px 0px 9px 0px #00000040",
+  submitBtn: {
+    mt: 1,
+    backgroundColor: "#111827",
+    px: 4.5,
+    py: 1.4,
     borderRadius: "10px",
-    padding: "40px 0 20px 0",
-    display: "flex",
-    justifyContent: "center",
+    textTransform: "none",
+    fontWeight: 600,
+    fontSize: "16px",
+    "&:hover": {
+      backgroundColor: "#030712",
+    },
   },
 };
+
+const toYMD = (dateObj) => {
+  const year = dateObj.getFullYear();
+  const month = `${dateObj.getMonth() + 1}`.padStart(2, "0");
+  const day = `${dateObj.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const startOfDay = (dateObj) => new Date(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate());
 
 const Booking = () => {
   const [selectedNumber, setSelectedNumber] = useState(1);
   const [selectedDate, setSelectedDate] = useState("");
   const [selectGuest, setSelectGuest] = useState(10);
-  const handleTableChange = (event) => {
-    setSelectedNumber(event.target.value);
+  const [visibleMonth, setVisibleMonth] = useState(() => startOfDay(new Date()));
+
+  const today = useMemo(() => startOfDay(new Date()), []);
+
+  const savedEventMap = useMemo(
+    () => new Map(SAVED_EVENTS.map((event) => [event.date, event.title])),
+    []
+  );
+
+  const monthLabel = visibleMonth.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const daysInMonth = new Date(
+    visibleMonth.getFullYear(),
+    visibleMonth.getMonth() + 1,
+    0
+  ).getDate();
+
+  const monthStartDay = new Date(
+    visibleMonth.getFullYear(),
+    visibleMonth.getMonth(),
+    1
+  ).getDay();
+
+  const calendarCells = [
+    ...Array(monthStartDay).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, index) => {
+      const value = new Date(
+        visibleMonth.getFullYear(),
+        visibleMonth.getMonth(),
+        index + 1
+      );
+      const formattedDate = toYMD(value);
+      const isPast = value < today;
+      const isBlocked = savedEventMap.has(formattedDate);
+
+      return {
+        day: index + 1,
+        value,
+        formattedDate,
+        isPast,
+        isBlocked,
+      };
+    }),
+  ];
+
+  const canMovePreviousMonth =
+    visibleMonth.getFullYear() > today.getFullYear() ||
+    (visibleMonth.getFullYear() === today.getFullYear() &&
+      visibleMonth.getMonth() > today.getMonth());
+
+  const selectedEventTitle = savedEventMap.get(selectedDate);
+
+  const handleDateSelect = (dateInfo) => {
+    if (dateInfo.isPast || dateInfo.isBlocked) return;
+    setSelectedDate(dateInfo.formattedDate);
   };
 
-  const handleDataChange = (event) => {
-    setSelectedDate(event.target.value);
+  const handleInputDateChange = (event) => {
+    const value = event.target.value;
+    if (!value) {
+      setSelectedDate("");
+      return;
+    }
+
+    if (savedEventMap.has(value)) return;
+
+    const parsedDate = startOfDay(new Date(value));
+    if (parsedDate < today) return;
+
+    setSelectedDate(value);
+    setVisibleMonth(parsedDate);
   };
-  const handleGuestChange = (event) => {
-    setSelectGuest(event.target.value);
-  };
+
   return (
     <Box sx={Styles.menusBox}>
       <Typography variant="h4" sx={Styles.menuHeading}>
-        Book Your Table
+        Book Your Event
       </Typography>
-      <Box sx={Styles.booktableBox}>
-        <Box sx={Styles.bookingForm}>
-          <Grid sx={Styles.inputGroup}>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Name</Typography>
+
+      <Grid container spacing={3} sx={Styles.bookingCard}>
+        <Grid item xs={12} lg={7}>
+          <Typography sx={Styles.sectionTitle}>Event Booking Details</Typography>
+          <Grid container spacing={2.2}>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Name</Typography>
+              <TextField variant="outlined" sx={Styles.inputStyle} placeholder="Your name" />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Mobile</Typography>
               <TextField
-                id="outlined-basic"
-                variant="outlined"
-                sx={Styles.inputStyle}
-                placeholder="Your name"
-              />
-            </Box>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Mobile</Typography>
-              <TextField
-                id="outlined-basic"
                 variant="outlined"
                 sx={Styles.inputStyle}
                 placeholder="Mobile number"
               />
-            </Box>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Tables Count</Typography>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Tables Count</Typography>
               <Select
-                labelId="number-select-label"
-                id="number-select"
                 value={selectedNumber}
-                onChange={handleTableChange}
+                onChange={(event) => setSelectedNumber(event.target.value)}
                 sx={Styles.inputStyle}
-                displayEmpty
               >
                 {[...Array(8)].map((_, index) => (
                   <MenuItem key={index + 1} value={index + 1}>
@@ -129,70 +201,159 @@ const Booking = () => {
                   </MenuItem>
                 ))}
               </Select>
-            </Box>
-          </Grid>
-          <Grid sx={Styles.inputGroup}>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Event Name</Typography>
-              <TextField
-                id="outlined-basic"
-                variant="outlined"
-                sx={Styles.inputStyle}
-                placeholder="Event name"
-              />
-            </Box>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Date & Time</Typography>
-
-              <TextField
-                id="date-select"
-                type="date"
-                value={selectedDate}
-                sx={Styles.inputStyle}
-                onChange={handleDataChange}
-                InputLabelProps={{
-                  shrink: true,
-                }}
-              />
-            </Box>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>Guest Count</Typography>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Event Name</Typography>
+              <TextField variant="outlined" sx={Styles.inputStyle} placeholder="Event name" />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Guest Count</Typography>
               <Select
-                labelId="number-select-label"
-                id="number-select"
                 value={selectGuest}
-                onChange={handleGuestChange}
+                onChange={(event) => setSelectGuest(event.target.value)}
                 sx={Styles.inputStyle}
-                displayEmpty
               >
-                {[...Array(50)].map((_, index) => (
+                {[...Array(250)].map((_, index) => (
                   <MenuItem key={index + 1} value={index + 1}>
                     {index + 1}
                   </MenuItem>
                 ))}
               </Select>
-            </Box>
-          </Grid>
-          <Grid sx={{ ...Styles.inputGroup, alignSelf: "flex-start" }}>
-            <Box sx={Styles.inputBox}>
-              <Typography sx={Styles.inputName}>
-                Add your custome Requirements
-              </Typography>
-
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Typography sx={Styles.label}>Selected Date</Typography>
               <TextField
-                id="outlined-multiline-static"
-                multiline
-                rows={2}
+                type="date"
+                value={selectedDate}
+                onChange={handleInputDateChange}
+                inputProps={{ min: toYMD(today) }}
                 sx={Styles.inputStyle}
-                placeholder="Customization"
               />
-            </Box>
+              {selectedEventTitle && (
+                <Typography sx={{ color: "#dc2626", fontSize: "12px", mt: 0.8, textAlign: "left" }}>
+                  This day is already blocked: {selectedEventTitle}
+                </Typography>
+              )}
+            </Grid>
+            <Grid item xs={12}>
+              <Typography sx={Styles.label}>Special Requirements</Typography>
+              <TextField
+                multiline
+                rows={3}
+                sx={Styles.inputStyle}
+                placeholder="Decoration theme, cuisine preference, timing notes..."
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Button variant="contained" sx={Styles.submitBtn}>
+                Submit Booking Request
+              </Button>
+            </Grid>
           </Grid>
-          <Button variant="contained" sx={Styles.submitBtn}>
-            Submit
-          </Button>
-        </Box>
-      </Box>
+        </Grid>
+
+        <Grid item xs={12} lg={5}>
+          <Typography sx={Styles.sectionTitle}>Availability Calendar</Typography>
+          <Box
+            sx={{
+              p: 2,
+              borderRadius: "14px",
+              border: "1px solid #e5e7eb",
+              backgroundColor: "#fff",
+            }}
+          >
+            <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1.5}>
+              <Button
+                onClick={() =>
+                  canMovePreviousMonth &&
+                  setVisibleMonth(
+                    new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() - 1, 1)
+                  )
+                }
+                disabled={!canMovePreviousMonth}
+                sx={{ minWidth: "38px", p: 0.6 }}
+              >
+                <ChevronLeftRoundedIcon />
+              </Button>
+              <Typography sx={{ fontWeight: 700 }}>{monthLabel}</Typography>
+              <Button
+                onClick={() =>
+                  setVisibleMonth(
+                    new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 1)
+                  )
+                }
+                sx={{ minWidth: "38px", p: 0.6 }}
+              >
+                <ChevronRightRoundedIcon />
+              </Button>
+            </Stack>
+
+            <Grid container columns={7} spacing={0.7}>
+              {WEEK_DAYS.map((dayName) => (
+                <Grid item xs={1} key={dayName}>
+                  <Typography sx={{ fontSize: "11px", color: "#6b7280", fontWeight: 700 }}>
+                    {dayName}
+                  </Typography>
+                </Grid>
+              ))}
+              {calendarCells.map((cell, index) => (
+                <Grid item xs={1} key={`${cell?.formattedDate || "blank"}-${index}`}>
+                  {!cell ? (
+                    <Box sx={{ height: "38px" }} />
+                  ) : (
+                    <Button
+                      onClick={() => handleDateSelect(cell)}
+                      disabled={cell.isPast || cell.isBlocked}
+                      sx={{
+                        minWidth: "100%",
+                        height: "38px",
+                        p: 0,
+                        borderRadius: "8px",
+                        fontWeight: 700,
+                        color: cell.formattedDate === selectedDate ? "#fff" : "#111827",
+                        bgcolor:
+                          cell.formattedDate === selectedDate
+                            ? "#111827"
+                            : cell.isBlocked
+                            ? "#fee2e2"
+                            : cell.isPast
+                            ? "#f3f4f6"
+                            : "transparent",
+                        border: cell.isBlocked ? "1px solid #fca5a5" : "1px solid #e5e7eb",
+                        "&:hover": {
+                          bgcolor:
+                            !cell.isPast && !cell.isBlocked && cell.formattedDate !== selectedDate
+                              ? "#f9fafb"
+                              : undefined,
+                        },
+                      }}
+                    >
+                      {cell.day}
+                    </Button>
+                  )}
+                </Grid>
+              ))}
+            </Grid>
+
+            <Stack direction="row" spacing={1} mt={2} flexWrap="wrap" useFlexGap>
+              <Chip icon={<CalendarMonthRoundedIcon />} label="Available" size="small" />
+              <Chip label="Past dates blocked" size="small" sx={{ bgcolor: "#f3f4f6" }} />
+              <Chip label="Booked dates blocked" size="small" sx={{ bgcolor: "#fee2e2" }} />
+            </Stack>
+
+            <Typography sx={{ textAlign: "left", mt: 2, fontWeight: 600, fontSize: "14px" }}>
+              Saved events:
+            </Typography>
+            <Stack spacing={0.8} mt={0.8}>
+              {SAVED_EVENTS.map((event) => (
+                <Typography key={event.date} sx={{ textAlign: "left", fontSize: "13px", color: "#374151" }}>
+                  {event.date} — {event.title}
+                </Typography>
+              ))}
+            </Stack>
+          </Box>
+        </Grid>
+      </Grid>
     </Box>
   );
 };

--- a/src/Component/Header/Header.js
+++ b/src/Component/Header/Header.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { AppBar, Toolbar, Typography, IconButton, Box } from "@mui/material";
 
 const Styles = {

--- a/src/Pages/Main/Main.js
+++ b/src/Pages/Main/Main.js
@@ -14,8 +14,8 @@ const Main = () => {
   return (
     <>
       <Header activeOption={activeOption} setActiveOption={setActiveOption} />
-      {activeOption == "Menus" && <MenuCard />}
-      {activeOption == "About Us" && (
+      {activeOption === "Menus" && <MenuCard />}
+      {activeOption === "About Us" && (
         <>
           <Heading />
           <SubHeading />


### PR DESCRIPTION
### Motivation
- Provide a polished, responsive booking UI for events that prevents users from choosing unavailable dates. 
- Surface saved bookings visually and prevent collisions by blocking already-booked and past dates. 
- Improve code quality by removing unused imports and fixing loose equality checks.

### Description
- Rebuilt the booking UI into a two-column, responsive layout and form; primary changes live in `src/Component/Booking/Booking.js`. 
- Added an availability calendar that: blocks all past dates, blocks dates that have saved events, prevents navigating to months before the current month, and prevents selecting blocked dates via the calendar or the date input. 
- Displayed saved events and availability legends in the calendar panel for user clarity. 
- Minor cleanups across the app including removing unused imports from `src/App.js` and `src/Component/Banner/Banner.js`, removing an unused hook import in `src/Component/Header/Header.js`, and replacing `==` with `===` in `src/Pages/Main/Main.js`.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm test -- --watch=false` and the test suite failed due to an environment/test issue: `IntersectionObserver is not defined` originating from `src/Component/useInView.js`. 
- A screenshot of the updated booking section was generated during validation to verify UI layout (artifact available in the build run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3071566948327828444f3419ea91a)