### PR TITLE
Improve responsive UI for mobile/iPad, set Home as default, and refresh menu data

### DIFF
--- a/public/menucard.json
+++ b/public/menucard.json
@@ -2,111 +2,141 @@
   {
     "id": 1,
     "main_course": "Non-Veg Special",
-    "special": "Chicken / Mutton",
+    "special": "Chicken / Mutton / Seafood",
     "foods": [
       {
         "id": 1,
-        "name": "Tandoori Chicken",
-        "description": "Char-grilled chicken marinated overnight in yogurt and aromatic spices."
+        "name": "🍗 Chicken Curry Thali",
+        "description": "Rustic village-style spicy chicken curry served with rice, roti, dal, pickle, and salad."
       },
       {
         "id": 2,
-        "name": "Butter Chicken",
-        "description": "Tender chicken in a silky tomato-butter gravy with mild spices."
+        "name": "🐟 Fish Fry Thali",
+        "description": "Fresh river fish marinated in local spices, shallow fried and served with bhakri and solkadhi."
       },
       {
         "id": 3,
-        "name": "Mutton Rogan Josh",
-        "description": "Slow-cooked mutton curry with Kashmiri chili, cardamom, and cloves."
+        "name": "🍖 Mutton Rassa Thali",
+        "description": "Authentic Maharashtrian spicy mutton gravy paired with jowar bhakri and onion chutney."
       },
       {
         "id": 4,
-        "name": "Chicken Biryani",
-        "description": "Fragrant basmati rice layered with spiced chicken and fresh herbs."
+        "name": "🍛 Chicken Handi",
+        "description": "Slow-cooked country chicken prepared in a clay pot with rich desi masala."
       },
       {
         "id": 5,
-        "name": "Fish Tikka",
-        "description": "Smoky, grilled fish cubes finished with lemon and coriander."
+        "name": "🔥 Tandoori Chicken (Desi Style)",
+        "description": "Smoky, charcoal-grilled chicken marinated in village-style yogurt and spices."
       },
       {
         "id": 6,
-        "name": "Prawn Masala",
-        "description": "Juicy prawns tossed in onion-tomato masala with coastal flavors."
+        "name": "🥘 Anda Curry (Village Egg Curry)",
+        "description": "Boiled eggs simmered in thick, spicy onion-tomato gravy."
+      },
+      {
+        "id": 7,
+        "name": "🐓 Desi Chicken Sukka",
+        "description": "Dry roasted chicken cooked with coconut and traditional rural spices."
+      },
+      {
+        "id": 8,
+        "name": "🐐 Mutton Sukka",
+        "description": "Tender mutton slow-roasted with fresh ground masala and curry leaves."
+      },
+      {
+        "id": 9,
+        "name": "🦐 Prawn Masala",
+        "description": "Juicy prawns cooked in coastal-style spicy gravy with a hint of coconut."
+      },
+      {
+        "id": 10,
+        "name": "🍗 Chicken Biryani (Village Style)",
+        "description": "Fragrant rice layered with spicy chicken and cooked in traditional dum method."
       }
     ]
   },
   {
     "id": 2,
     "main_course": "Veg Special",
-    "special": "Curry / Paneer",
+    "special": "Classic Rural Flavors",
     "foods": [
       {
         "id": 1,
-        "name": "Paneer Butter Masala",
-        "description": "Soft paneer cubes simmered in a creamy tomato and cashew gravy."
+        "name": "🥗 Veg Thali (Gaon Style)",
+        "description": "Simple and hearty meal with seasonal sabzi, dal, rice, roti/bhakri, pickle, and chutney."
       },
       {
         "id": 2,
-        "name": "Veg Kolhapuri",
-        "description": "Mixed vegetables cooked in a robust and spicy Maharashtrian masala."
+        "name": "🌾 Jowar Bhakri with Pithla",
+        "description": "Soft millet flatbread served with spicy gram flour curry, a true rural classic."
       },
       {
         "id": 3,
-        "name": "Dal Tadka",
-        "description": "Yellow lentils tempered with garlic, cumin, and ghee."
+        "name": "🍆 Baingan Bharta",
+        "description": "Fire-roasted brinjal mashed and cooked with onions, tomatoes, and desi spices."
       },
       {
         "id": 4,
-        "name": "Mushroom Pepper Fry",
-        "description": "Sauteed mushrooms with crushed pepper, curry leaves, and onions."
+        "name": "🥔 Aloo Jeera",
+        "description": "Simple village-style potatoes sautéed with cumin and fresh coriander."
       },
       {
         "id": 5,
-        "name": "Malai Kofta",
-        "description": "Cottage cheese dumplings in a rich, mildly sweet cream sauce."
+        "name": "🌿 Palak Dal",
+        "description": "Yellow lentils cooked with fresh spinach and mild rural tempering."
       },
       {
         "id": 6,
-        "name": "Veg Pulao",
-        "description": "Lightly spiced rice tossed with seasonal vegetables and herbs."
+        "name": "🧀 Paneer Masala (Desi Style)",
+        "description": "Cottage cheese cubes simmered in thick, rustic onion-tomato gravy."
+      },
+      {
+        "id": 7,
+        "name": "🥒 Bharli Vangi",
+        "description": "Stuffed brinjals filled with spicy coconut-peanut masala, cooked Maharashtrian style."
+      },
+      {
+        "id": 8,
+        "name": "🍚 Vegetable Pulao",
+        "description": "Fragrant rice cooked with seasonal vegetables and mild whole spices."
       }
     ]
   },
   {
     "id": 3,
-    "main_course": "Drinks Special",
-    "special": "Mocktails",
+    "main_course": "Drinks",
+    "special": "Soft Drinks / Fresh Juices",
     "foods": [
       {
         "id": 1,
-        "name": "Virgin Mojito",
-        "description": "Refreshing mint, lime, and soda cooler with a citrusy kick."
+        "name": "🥤 Sprite",
+        "description": "Chilled lemon-lime soft drink, perfect with spicy meals."
       },
       {
         "id": 2,
-        "name": "Blue Lagoon",
-        "description": "Chilled lemonade blended with blue curaçao flavor and crushed ice."
+        "name": "🥤 Coca-Cola",
+        "description": "Classic cold cola to refresh after a heavy thali."
       },
       {
         "id": 3,
-        "name": "Watermelon Cooler",
-        "description": "Fresh watermelon juice with basil notes and a dash of lime."
+        "name": "🥤 Thums Up",
+        "description": "Strong and fizzy cola with bold taste."
       },
       {
         "id": 4,
-        "name": "Pineapple Ginger Fizz",
-        "description": "Tropical pineapple drink balanced with gentle ginger spice."
+        "name": "🍊 Fresh Orange Juice",
+        "description": "Naturally sweet and tangy seasonal juice."
       },
       {
         "id": 5,
-        "name": "Masala Buttermilk",
-        "description": "Traditional salted chaas with roasted cumin and coriander."
+        "name": "🥭 Mango Juice",
+        "description": "Thick and refreshing mango drink, village favorite."
       },
       {
         "id": 6,
-        "name": "Cold Coffee",
-        "description": "Creamy, frothy coffee served chilled with chocolate drizzle."
+        "name": "🍋 Fresh Lime Soda",
+        "description": "Sweet or salty nimbu soda with chilled fizz."
       }
     ]
   }

--- a/src/Component/Footer/Footer.js
+++ b/src/Component/Footer/Footer.js
@@ -2,13 +2,14 @@ import { Box, Typography, Grid } from "@mui/material";
 
 const Styles = {
   menusBox: {
-    padding: "0 60px",
+    padding: { xs: "0 16px", sm: "0 24px", md: "0 60px" },
     marginTop: "60px",
+    marginBottom: "30px",
   },
   menuHeading: {
-    marginBottom: "40px",
+    marginBottom: "28px",
     textAlign: "left",
-    fontSize: "35px",
+    fontSize: { xs: "28px", md: "35px" },
     fontWeight: 600,
     fontFamily: "Inter",
   },
@@ -17,7 +18,10 @@ const Styles = {
   },
   footerStyle: {
     display: "flex",
+    flexDirection: { xs: "column", md: "row" },
     justifyContent: "space-around",
+    alignItems: { xs: "flex-start", md: "stretch" },
+    gap: { xs: 3, md: 1 },
     marginBottom: "40px",
   },
   contactStyle: {
@@ -27,7 +31,7 @@ const Styles = {
   contactBox: {
     display: "flex",
     flexDirection: "column",
-    gap: "25px",
+    gap: "20px",
   },
   socialBox: {
     display: "flex",
@@ -35,7 +39,7 @@ const Styles = {
     gap: "22px",
   },
   address: {
-    width: "335px",
+    width: { xs: "100%", md: "335px" },
     textAlign: "left",
     fontSize: "16px",
     fontWeight: 500,
@@ -97,26 +101,10 @@ const Footer = () => {
             <Typography sx={Styles.contact}>7083322271</Typography>
           </Grid>
           <Grid sx={Styles.socialBox}>
-            <img
-              style={Styles.socialIcon}
-              src="./images/social/facebook.png"
-              alt=""
-            />
-            <img
-              style={Styles.socialIcon}
-              src="./images/social/linkedin.png"
-              alt=""
-            />
-            <img
-              style={Styles.socialIcon}
-              src="./images/social/youtube.png"
-              alt=""
-            />
-            <img
-              style={Styles.socialIcon}
-              src="./images/social/instagram.png"
-              alt=""
-            />
+            <img style={Styles.socialIcon} src="./images/social/facebook.png" alt="" />
+            <img style={Styles.socialIcon} src="./images/social/linkedin.png" alt="" />
+            <img style={Styles.socialIcon} src="./images/social/youtube.png" alt="" />
+            <img style={Styles.socialIcon} src="./images/social/instagram.png" alt="" />
           </Grid>
         </Box>
         <Box>

--- a/src/Component/Header/Header.js
+++ b/src/Component/Header/Header.js
@@ -1,77 +1,58 @@
 import React from "react";
-import { AppBar, Toolbar, Typography, IconButton, Box } from "@mui/material";
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Box,
+  Stack,
+} from "@mui/material";
+import PhoneInTalkRoundedIcon from "@mui/icons-material/PhoneInTalkRounded";
 
 const Styles = {
   headerName: {
-    marginLeft: 10,
-    fontSize: "26px",
+    marginLeft: 1,
+    fontSize: { xs: "20px", sm: "24px", md: "26px" },
     fontFamily: "Inter",
     fontWeight: 500,
   },
-  callIcon: {
-    height: "34px",
-    width: "34px",
-  },
   options: {
-    margin: "0 25px",
-    fontSize: "20px",
+    margin: { xs: "0", sm: "0 10px", md: "0 18px" },
+    fontSize: { xs: "15px", sm: "17px", md: "20px" },
     fontFamily: "Inter",
     fontWeight: 500,
     position: "relative",
     cursor: "pointer",
-    padding: "0 10px",
+    padding: { xs: "0 4px", sm: "0 8px", md: "0 10px" },
     "&.active": {
       borderBottom: "2px solid black",
     },
   },
-  bookingNumber: {
-    position: "absolute",
-    top: "-17px",
-    right: "-23px",
-    height: "27px",
-    width: "27px",
-    background: "black",
-    borderRadius: "50%",
-    fontSize: "16px",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    color: "#FFFFFF",
-    fontFamily: "Inter",
-  },
 };
 
 const Header = ({ activeOption, setActiveOption }) => {
-  const handleOptionClick = (option) => {
-    setActiveOption(option);
-  };
-
   return (
     <AppBar
       position="static"
       color="transparent"
       elevation={0}
-      sx={{ padding: "5px" }}
+      sx={{ px: { xs: 1, md: 2 }, py: 0.8 }}
     >
-      <Toolbar>
+      <Toolbar disableGutters sx={{ minHeight: { xs: "72px", md: "86px" } }}>
         <Box display="flex" alignItems="center">
           <img
             src="./images/logo.png"
             alt="Hidden Leaf"
-            style={{ width: 70, height: 70, borderRadius: "50%" }}
+            style={{ width: 58, height: 58, borderRadius: "50%" }}
           />
-          <Typography
-            variant="h6"
-            color="textPrimary"
-            style={Styles.headerName}
-          >
+          <Typography variant="h6" color="textPrimary" sx={Styles.headerName}>
             Hidden-Leaf
           </Typography>
         </Box>
         <Box flexGrow={1} />
-        <Box display="flex" alignItems="center">
-          <IconButton edge="end" color="inherit" sx={{ marginRight: 2 }}>
-            <img src="./images/call.png" alt="" style={Styles.callIcon} />
+        <Stack direction="row" alignItems="center" spacing={{ xs: 0.4, sm: 1.1 }}>
+          <IconButton edge="end" color="inherit" sx={{ mr: { xs: 0, sm: 1 } }}>
+            <PhoneInTalkRoundedIcon sx={{ fontSize: { xs: 22, sm: 28 } }} />
           </IconButton>
           {["Menus", "Home"].map((option) => (
             <Typography
@@ -82,23 +63,12 @@ const Header = ({ activeOption, setActiveOption }) => {
                 ...Styles.options,
                 ...(activeOption === option && Styles.options["&.active"]),
               }}
-              onClick={() => handleOptionClick(option)}
+              onClick={() => setActiveOption(option)}
             >
               {option}
-              {option === "Posts" && (
-                <Box>
-                  <Typography
-                    variant="v6"
-                    color="textPrimary"
-                    sx={Styles.bookingNumber}
-                  >
-                    3
-                  </Typography>
-                </Box>
-              )}
             </Typography>
           ))}
-        </Box>
+        </Stack>
       </Toolbar>
     </AppBar>
   );

--- a/src/Component/Menus/Menus.js
+++ b/src/Component/Menus/Menus.js
@@ -5,11 +5,14 @@ import useInView from "../../Component/useInView";
 
 const Styles = {
   imageItem: {
-    height: "140px",
+    width: { xs: "100%", sm: "150px" },
+    height: { xs: "170px", sm: "140px" },
     borderRadius: "4px",
+    objectFit: "cover",
   },
   itemBox: {
     display: "flex",
+    flexDirection: { xs: "column", sm: "row" },
     justifyContent: "flex-start",
     alignItems: "flex-start",
     gap: "15px",
@@ -26,13 +29,13 @@ const Styles = {
     width: "100%",
   },
   menusBox: {
-    padding: "0 60px",
+    padding: { xs: "0 16px", sm: "0 24px", md: "0 60px" },
     marginTop: "60px",
   },
   menuHeading: {
-    marginBottom: "40px",
+    marginBottom: "28px",
     textAlign: "left",
-    fontSize: "35px",
+    fontSize: { xs: "28px", md: "35px" },
     fontWeight: 600,
     fontFamily: "Inter",
   },
@@ -41,6 +44,7 @@ const Styles = {
     fontSize: "16px",
     color: "#828282",
     cursor: "pointer",
+    textAlign: "left",
   },
 };
 
@@ -49,42 +53,40 @@ const Menus = () => {
   const [visibleItems, setVisibleItems] = useState(4);
   const [setRef1, inView1] = useInView({ threshold: 0.1 });
   const [setRef2, inView2] = useInView({ threshold: 0.1 });
-  const fetchMenus = async () => {
-    try {
-      const menuData = await fetch("menus.json");
-      const response = await menuData.json();
-      setMenu(response);
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   useEffect(() => {
+    const fetchMenus = async () => {
+      try {
+        const menuData = await fetch("menus.json");
+        const response = await menuData.json();
+        setMenu(response);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
     fetchMenus();
   }, []);
-
-  const handleLoadMore = () => {
-    setVisibleItems((prev) => prev + 4);
-  };
 
   return (
     <Box sx={Styles.menusBox}>
       <Typography variant="h4" sx={Styles.menuHeading}>
         Our Highest-Rated Exquisite Menus
       </Typography>
-      <Grid container spacing={4}>
+      <Grid container spacing={3}>
         {menu.slice(0, visibleItems).map((item) => (
-          <Grid item xs={6} key={item.id} sx={Styles.itemBox}>
+          <Grid item xs={12} md={6} key={item.id} sx={Styles.itemBox}>
             <motion.div
               ref={setRef1}
               initial={{ opacity: 0, y: 50 }}
               animate={{ opacity: inView1 ? 1 : 0, y: inView1 ? 0 : 50 }}
               transition={{ duration: 0.5 }}
             >
-              <img
+              <Box
+                component="img"
                 src={`./images/menus/${item.image}`}
                 alt={item.name}
-                style={Styles.imageItem}
+                sx={Styles.imageItem}
               />
             </motion.div>
             <Box>
@@ -105,7 +107,7 @@ const Menus = () => {
         <Typography
           variant="h6"
           sx={Styles.menuLoading}
-          onClick={handleLoadMore}
+          onClick={() => setVisibleItems((prev) => prev + 4)}
         >
           Load More...
         </Typography>

--- a/src/Pages/Main/Main.js
+++ b/src/Pages/Main/Main.js
@@ -9,13 +9,13 @@ import SubHeading from "../SubHeading/SubHeading";
 import MenuCard from "../MenuCard/MenuCard";
 
 const Main = () => {
-  const [activeOption, setActiveOption] = useState("About Us");
+  const [activeOption, setActiveOption] = useState("Home");
 
   return (
     <>
       <Header activeOption={activeOption} setActiveOption={setActiveOption} />
       {activeOption === "Menus" && <MenuCard />}
-      {activeOption === "About Us" && (
+      {activeOption === "Home" && (
         <>
           <Heading />
           <SubHeading />

--- a/src/Pages/MenuCard/MenuCard.js
+++ b/src/Pages/MenuCard/MenuCard.js
@@ -19,7 +19,7 @@ const Styles = {
     fontSize: "24px",
     padding: "20px",
     position: "relative",
-    left: "20px",
+    left: { xs: 0, md: "20px" },
   },
   menuHeading: {
     marginBottom: "40px",
@@ -51,27 +51,27 @@ const Styles = {
     width: { xs: "100%", md: "90%" },
   },
   heading: {
-    fontSize: "30px",
+    fontSize: { xs: "24px", md: "30px" },
     fontWeight: 700,
     fontFamily: "Inter",
   },
   subHeading: {
     color: "#F2DE2E",
-    fontSize: "27px",
+    fontSize: { xs: "22px", md: "27px" },
     fontWeight: 700,
     fontFamily: "Inter",
-    marginLeft: "40px",
+    marginLeft: { xs: 0, md: "40px" },
   },
   foodName: {
     fontWeight: 600,
     fontFamily: "Inter",
-    fontSize: "20px",
+    fontSize: { xs: "18px", md: "20px" },
   },
   foodDesc: {
     color: "#8A8080",
     fontWeight: 500,
     fontFamily: "Inter",
-    fontSize: "16px",
+    fontSize: { xs: "14px", md: "16px" },
   },
   menuBannerBox: {
     display: "grid",

--- a/src/Pages/SubHeading/SubHeading.js
+++ b/src/Pages/SubHeading/SubHeading.js
@@ -8,55 +8,58 @@ const Styles = {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    padding: "0 60px",
+    padding: { xs: "0 16px", sm: "0 24px", md: "0 60px" },
   },
   bannerTextBox: {
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
+    width: { xs: "100%", md: "auto" },
   },
   bannerSubText: {
     textAlign: "left",
-    width: "350px",
+    width: { xs: "100%", md: "350px" },
     color: "#828282",
   },
   bannerImage: {
-    height: "350px",
+    width: { xs: "100%", sm: "85%", md: "auto" },
+    maxWidth: "420px",
+    height: { xs: "220px", sm: "280px", md: "350px" },
+    objectFit: "cover",
     boxShadow: "0px 20px 20px 0px #b8b8b873",
   },
   banner2Box: {
-    flexDirection: "row-reverse",
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    padding: "0 40px",
+    padding: { xs: "0 16px", sm: "0 24px", md: "0 40px" },
   },
   bannerBox: {
     display: "flex",
     flexDirection: "column",
-    gap: "90px",
+    gap: { xs: "40px", md: "90px" },
   },
   bannerText: {
     fontFamily: "Inter",
-    fontSize: "40px",
+    fontSize: { xs: "28px", md: "40px" },
     fontWeight: 600,
-    width: "350px",
+    width: { xs: "100%", md: "350px" },
     textAlign: "left",
   },
   bannerTextBox2: {
     position: "relative",
-    left: "-10px",
+    left: { xs: 0, md: "-10px" },
   },
   bannerText2: {
     fontFamily: "Inter",
-    fontSize: "40px",
+    fontSize: { xs: "28px", md: "40px" },
     fontWeight: 600,
-    width: "450px",
+    width: { xs: "100%", md: "450px" },
     textAlign: "left",
   },
   bannerTextBox1: {
     position: "relative",
-    left: "10px",
+    left: { xs: 0, md: "10px" },
   },
 };
 
@@ -72,7 +75,13 @@ const SubHeading = () => {
         animate={{ opacity: inView1 ? 1 : 0, y: inView1 ? 0 : 100 }}
         transition={{ duration: 1 }}
       >
-        <Grid sx={Styles.banner1Box}>
+        <Grid
+          sx={{
+            ...Styles.banner1Box,
+            flexDirection: { xs: "column-reverse", md: "row" },
+            gap: { xs: 2.5, md: 0 },
+          }}
+        >
           <Box sx={{ ...Styles.bannerTextBox, ...Styles.bannerTextBox1 }}>
             <Typography sx={Styles.bannerText}>EXCLUSIVELY FOR YOU</Typography>
             <Typography sx={Styles.bannerSubText}>
@@ -80,9 +89,7 @@ const SubHeading = () => {
               hotel. Experience the thrill of the game with every bite!
             </Typography>
           </Box>
-          <Box>
-            <img src="./images/banner1.png" alt="" style={Styles.bannerImage} />
-          </Box>
+          <Box component="img" src="./images/banner1.png" alt="Special experience" sx={Styles.bannerImage} />
         </Grid>
       </motion.div>
       <motion.div
@@ -91,7 +98,13 @@ const SubHeading = () => {
         animate={{ opacity: inView2 ? 1 : 0, y: inView2 ? 0 : 50 }}
         transition={{ duration: 0.5 }}
       >
-        <Grid sx={Styles.banner2Box}>
+        <Grid
+          sx={{
+            ...Styles.banner2Box,
+            flexDirection: { xs: "column-reverse", md: "row-reverse" },
+            gap: { xs: 2.5, md: 0 },
+          }}
+        >
           <Box sx={{ ...Styles.bannerTextBox, ...Styles.bannerTextBox2 }}>
             <Typography sx={{ ...Styles.bannerText, ...Styles.bannerText2 }}>
               PLAN YOUR SPECIAL EVENTS
@@ -101,9 +114,7 @@ const SubHeading = () => {
               under the open sky with elegance and style!
             </Typography>
           </Box>
-          <Box>
-            <img src="./images/banner2.png" alt="" style={Styles.bannerImage} />
-          </Box>
+          <Box component="img" src="./images/banner2.png" alt="Event planning" sx={Styles.bannerImage} />
         </Grid>
       </motion.div>
     </Box>


### PR DESCRIPTION
### Motivation
- Make the site usable on phones and tablets by improving header, content, menus and footer layouts. 
- Ensure clicking `Home` shows the expected home content by making `Home` the default active section. 
- Replace the menu dataset with the requested non-veg, veg and drinks items so the menu page reflects the updated offerings.

### Description
- Set default navigation state to `Home` and render home components when `Home` is active by updating `src/Pages/Main/Main.js`. 
- Make the header compact and responsive with scaled typography and spacing and a simplified call control by updating `src/Component/Header/Header.js`. 
- Convert banner/sub-heading sections to responsive stacking and image resizing for smaller screens by updating `src/Pages/SubHeading/SubHeading.js`. 
- Update the menus preview grid to use mobile-first breakpoints, responsive images, and improved spacing by updating `src/Component/Menus/Menus.js`. 
- Tune `MenuCard` typography, offsets and mobile sizing for better readability on small screens by updating `src/Pages/MenuCard/MenuCard.js` and `src/Component/MenuCard/*` usage. 
- Make the footer stack on small screens and constrain text widths for readability by updating `src/Component/Footer/Footer.js`. 
- Replace `public/menucard.json` with the requested items: 10 non-veg entries, 8 veg entries, and the updated drinks list (Sprite, Coca‑Cola, Thums Up, Fresh Orange Juice, Mango Juice, Fresh Lime Soda). 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Started the development server with `npm start` and the app compiled successfully for local testing. 
- Performed automated browser checks with Playwright that captured screenshots for mobile home view and iPad menus view, and both runs completed successfully (artifacts: `artifacts/mobile-home.png`, `artifacts/ipad-menus.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a322c8b22083278a8af5a251a73205)