### PR TITLE
Improve menu alignment, mobile menu images, and Book CTA behavior

### DIFF
--- a/src/Component/Booking/Booking.js
+++ b/src/Component/Booking/Booking.js
@@ -232,7 +232,7 @@ const Booking = () => {
   };
 
   return (
-    <Box sx={Styles.menusBox}>
+    <Box id="booking-section" sx={Styles.menusBox}>
       <Typography variant="h4" sx={Styles.menuHeading}>Book Your Table</Typography>
 
       <Grid container spacing={3} sx={Styles.bookingCard} component="form" onSubmit={handleSubmit}>

--- a/src/Component/Header/Header.js
+++ b/src/Component/Header/Header.js
@@ -12,7 +12,7 @@ import PhoneInTalkRoundedIcon from "@mui/icons-material/PhoneInTalkRounded";
 const Styles = {
   headerName: {
     marginLeft: 1,
-    fontSize: { xs: "20px", sm: "24px", md: "26px" },
+    fontSize: { xs: "18px", sm: "24px", md: "26px" },
     fontFamily: "Inter",
     fontWeight: 500,
   },
@@ -40,10 +40,11 @@ const Header = ({ activeOption, setActiveOption }) => {
     >
       <Toolbar disableGutters sx={{ minHeight: { xs: "72px", md: "86px" } }}>
         <Box display="flex" alignItems="center">
-          <img
+          <Box
+            component="img"
             src="./images/logo.png"
             alt="Hidden Leaf"
-            style={{ width: 58, height: 58, borderRadius: "50%" }}
+            sx={{ width: { xs: 50, sm: 58 }, height: { xs: 50, sm: 58 }, borderRadius: "50%" }}
           />
           <Typography variant="h6" color="textPrimary" sx={Styles.headerName}>
             Hidden-Leaf
@@ -52,7 +53,7 @@ const Header = ({ activeOption, setActiveOption }) => {
         <Box flexGrow={1} />
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.4, sm: 1.1 }}>
           <IconButton edge="end" color="inherit" sx={{ mr: { xs: 0, sm: 1 } }}>
-            <PhoneInTalkRoundedIcon sx={{ fontSize: { xs: 22, sm: 28 } }} />
+            <PhoneInTalkRoundedIcon sx={{ fontSize: { xs: 19, sm: 28 } }} />
           </IconButton>
           {["Menus", "Home"].map((option) => (
             <Typography

--- a/src/Component/Menus/Menus.js
+++ b/src/Component/Menus/Menus.js
@@ -4,11 +4,26 @@ import { motion } from "framer-motion";
 import useInView from "../../Component/useInView";
 
 const Styles = {
-  imageItem: {
+  imageWrapper: {
     width: { xs: "100%", sm: "150px" },
-    height: { xs: "170px", sm: "140px" },
-    borderRadius: "4px",
+    height: { xs: "220px", sm: "140px" },
+    borderRadius: "6px",
+    overflow: "hidden",
+    position: "relative",
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      inset: 0,
+      boxShadow: { xs: "inset 0 0 28px rgba(0, 0, 0, 0.32)", sm: "none" },
+      pointerEvents: "none",
+      borderRadius: "inherit",
+    },
+  },
+  imageItem: {
+    width: "100%",
+    height: "100%",
     objectFit: "cover",
+    display: "block",
   },
   itemBox: {
     display: "flex",
@@ -16,6 +31,10 @@ const Styles = {
     justifyContent: "flex-start",
     alignItems: "flex-start",
     gap: "15px",
+  },
+  itemTextBox: {
+    width: "100%",
+    textAlign: "left",
   },
   itemName: {
     textAlign: "left",
@@ -81,15 +100,18 @@ const Menus = () => {
               initial={{ opacity: 0, y: 50 }}
               animate={{ opacity: inView1 ? 1 : 0, y: inView1 ? 0 : 50 }}
               transition={{ duration: 0.5 }}
+              style={{ width: "100%" }}
             >
-              <Box
-                component="img"
-                src={`./images/menus/${item.image}`}
-                alt={item.name}
-                sx={Styles.imageItem}
-              />
+              <Box sx={Styles.imageWrapper}>
+                <Box
+                  component="img"
+                  src={`./images/menus/${item.image}`}
+                  alt={item.name}
+                  sx={Styles.imageItem}
+                />
+              </Box>
             </motion.div>
-            <Box>
+            <Box sx={Styles.itemTextBox}>
               <motion.div
                 ref={setRef2}
                 initial={{ opacity: 0, y: 50 }}

--- a/src/Pages/Heading/Heading.js
+++ b/src/Pages/Heading/Heading.js
@@ -1,8 +1,4 @@
 import { Box, Button, Typography } from "@mui/material";
-import FlatwareIcon from "@mui/icons-material/Flatware";
-import DinnerDiningIcon from "@mui/icons-material/DinnerDining";
-import RestaurantMenuIcon from "@mui/icons-material/RestaurantMenu";
-import { motion } from "framer-motion";
 
 const Styles = {
   headingBox: {
@@ -38,51 +34,17 @@ const Styles = {
       backgroundColor: "black",
     },
   },
-  floatingIcon: {
-    position: "absolute",
-    color: "rgba(0, 0, 0, 0.1)",
-    zIndex: 1,
-  },
 };
 
-const floatingIcons = [
-  { Icon: FlatwareIcon, left: "8%", top: "18%", size: 52, duration: 5.5 },
-  {
-    Icon: DinnerDiningIcon,
-    left: "82%",
-    top: "26%",
-    size: 58,
-    duration: 6.5,
-  },
-  {
-    Icon: RestaurantMenuIcon,
-    left: "14%",
-    top: "72%",
-    size: 48,
-    duration: 5.8,
-  },
-  { Icon: FlatwareIcon, left: "88%", top: "68%", size: 44, duration: 7.1 },
-];
-
-const Heading = () => {
+const Heading = ({ onBookTableClick }) => {
   return (
     <Box sx={Styles.headingBox}>
-      {floatingIcons.map(({ Icon, left, top, size, duration }, index) => (
-        <motion.div
-          key={`${left}-${top}-${index}`}
-          style={{ ...Styles.floatingIcon, left, top }}
-          animate={{ y: [0, -15, 0], rotate: [0, 6, -6, 0] }}
-          transition={{ duration, repeat: Infinity, ease: "easeInOut" }}
-        >
-          <Icon sx={{ fontSize: size }} />
-        </motion.div>
-      ))}
       <Typography sx={Styles.heading}>Hidden-Leaf</Typography>
       <Typography sx={Styles.subHeading}>
         Embark on a journey of serenity at Hidden Leaf Resort, where luxury
         meets natural beauty. Find your perfect escape at our tranquil haven
       </Typography>
-      <Button variant="contained" sx={Styles.bookTableBtn}>
+      <Button variant="contained" sx={Styles.bookTableBtn} onClick={onBookTableClick}>
         Book Your table
       </Button>
     </Box>

--- a/src/Pages/Main/Main.js
+++ b/src/Pages/Main/Main.js
@@ -11,13 +11,18 @@ import MenuCard from "../MenuCard/MenuCard";
 const Main = () => {
   const [activeOption, setActiveOption] = useState("Home");
 
+  const scrollToBookingSection = () => {
+    const bookingElement = document.getElementById("booking-section");
+    bookingElement?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <>
       <Header activeOption={activeOption} setActiveOption={setActiveOption} />
       {activeOption === "Menus" && <MenuCard />}
       {activeOption === "Home" && (
         <>
-          <Heading />
+          <Heading onBookTableClick={scrollToBookingSection} />
           <SubHeading />
           <Menus />
           <Banner />

--- a/src/Pages/MenuCard/MenuCard.js
+++ b/src/Pages/MenuCard/MenuCard.js
@@ -19,7 +19,7 @@ const Styles = {
     fontSize: "24px",
     padding: "20px",
     position: "relative",
-    left: { xs: 0, md: "20px" },
+    left: 0,
   },
   menuHeading: {
     marginBottom: "40px",
@@ -46,9 +46,9 @@ const Styles = {
     display: "flex",
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: { xs: "15px 20px", md: "15px 100px" },
-    justifyContent: "space-around",
-    width: { xs: "100%", md: "90%" },
+    gap: { xs: "15px 20px", md: "15px 60px" },
+    justifyContent: "flex-start",
+    width: "100%",
   },
   heading: {
     fontSize: { xs: "24px", md: "30px" },


### PR DESCRIPTION
### Motivation
- Clean up menu layouts so dish entries and menu cards are consistently left-aligned and look correct across breakpoints. 
- Make the hero CTA scroll the user to the booking calendar for a smoother booking flow. 
- Improve mobile visuals for the highest-rated menus by showing images full-width with an inset shadow and slightly reduce header icon sizing to improve spacing on small screens.

### Description
- Wired the home hero `Book Your table` button to a handler passed from `Main` that smooth-scrolls to the booking calendar target `#booking-section`, and added that id to the booking container (`src/Pages/Main/Main.js`, `src/Pages/Heading/Heading.js`, `src/Component/Booking/Booking.js`).
- Removed the decorative floating dish icons and framer-motion import from the hero to simplify the heading and keep focus on the CTA (`src/Pages/Heading/Heading.js`).
- Reworked the Highest-Rated Exquisite Menus layout to render images in a wrapper that becomes full-width on mobile and applies an inset inner-shadow overlay for the requested visual effect (`src/Component/Menus/Menus.js`).
- Adjusted menu card layout to left-align food groups, remove the previous offset, and use `justifyContent: "flex-start"` with full-width behavior (`src/Pages/MenuCard/MenuCard.js`).
- Reduced the mobile sizes for header elements by changing logo sizing to responsive `sx` values and decreasing phone icon and small-screen title sizes (`src/Component/Header/Header.js`).

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran automated tests with `npm test -- --watchAll=false` which failed due to the test environment issue `ReferenceError: IntersectionObserver is not defined` originating from the existing jsdom setup, not changes in this PR. 
- Performed manual automated browser checks using Playwright which confirmed that clicking `Book Your table` scrolls to `#booking-section`, and captured a mobile screenshot showing full-width menu images with the inset shadow effect (artifacts available from the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3261031dc8327bc7e291d93fc66b3)