### PR TITLE
Header call action, footer socials+map, and smoother mobile menu reveal

### DIFF
--- a/src/Component/Footer/Footer.js
+++ b/src/Component/Footer/Footer.js
@@ -1,4 +1,13 @@
-import { Box, Typography, Grid } from "@mui/material";
+import { Box, Typography, Grid, IconButton, Link } from "@mui/material";
+import WhatsAppIcon from "@mui/icons-material/WhatsApp";
+import InstagramIcon from "@mui/icons-material/Instagram";
+import FacebookIcon from "@mui/icons-material/Facebook";
+import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
+
+const ADDRESS =
+  "PX67+X5W, Kondhve Khind, At Post - Kondhve, beside Shahupuri Kondhve Road, Satara, Maharashtra 415002";
+const MAP_LINK =
+  "https://www.google.com/maps/search/?api=1&query=PX67%2BX5W%2C+Kondhve+Khind%2C+At+Post+-+Kondhve%2C+beside+Shahupuri+Kondhve+Road%2C+Satara%2C+Maharashtra+415002";
 
 const Styles = {
   menusBox: {
@@ -13,9 +22,6 @@ const Styles = {
     fontWeight: 600,
     fontFamily: "Inter",
   },
-  socialIcon: {
-    height: "18px",
-  },
   footerStyle: {
     display: "flex",
     flexDirection: { xs: "column", md: "row" },
@@ -27,6 +33,7 @@ const Styles = {
   contactStyle: {
     display: "flex",
     flexDirection: "row",
+    gap: "8px",
   },
   contactBox: {
     display: "flex",
@@ -36,7 +43,7 @@ const Styles = {
   socialBox: {
     display: "flex",
     flexDirection: "row",
-    gap: "22px",
+    gap: "8px",
   },
   address: {
     width: { xs: "100%", md: "335px" },
@@ -53,23 +60,12 @@ const Styles = {
     alignItems: "flex-start",
     gap: "10px",
   },
-  detailsBox: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start",
-    gap: "10px",
-    "& .MuiTypography-root": {
-      fontSize: "16px",
-      fontWeight: 500,
-      fontFamily: "Inter",
-      color: "#454545",
-    },
-  },
   contact: {
     color: "#6E6E6E",
     fontFamily: "Inter",
     fontWeight: 600,
     fontSize: "20px",
+    textDecoration: "none",
   },
   mob: {
     fontFamily: "Inter",
@@ -81,6 +77,19 @@ const Styles = {
     fontFamily: "Inter",
     fontSize: "20px",
     fontWeight: 500,
+  },
+  iconButton: {
+    color: "#1f1f1f",
+    border: "1px solid #d8d8d8",
+    borderRadius: "50%",
+  },
+  mapLink: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "6px",
+    fontWeight: 600,
+    color: "#2f5eff",
+    textDecoration: "none",
   },
 };
 
@@ -94,33 +103,55 @@ const Footer = () => {
         <Box sx={Styles.contactBox}>
           <Grid sx={Styles.contactStyle}>
             <Typography sx={Styles.mob}>Mob -</Typography>
-            <Typography sx={Styles.contact}>7030092200</Typography>
-          </Grid>
-          <Grid sx={Styles.contactStyle}>
-            <Typography sx={Styles.mob}>Mob -</Typography>
-            <Typography sx={Styles.contact}>7083322271</Typography>
+            <Link href="tel:+917030092200" sx={Styles.contact}>
+              +91 70300 92200
+            </Link>
           </Grid>
           <Grid sx={Styles.socialBox}>
-            <img style={Styles.socialIcon} src="./images/social/facebook.png" alt="" />
-            <img style={Styles.socialIcon} src="./images/social/linkedin.png" alt="" />
-            <img style={Styles.socialIcon} src="./images/social/youtube.png" alt="" />
-            <img style={Styles.socialIcon} src="./images/social/instagram.png" alt="" />
-          </Grid>
-        </Box>
-        <Box>
-          <Grid sx={Styles.detailsBox}>
-            <Typography>Customer reviews</Typography>
-            <Typography>Booking Tables</Typography>
-            <Typography>Contact Us</Typography>
+            <IconButton
+              component={Link}
+              href="https://wa.me/917030092200"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open WhatsApp"
+              sx={Styles.iconButton}
+            >
+              <WhatsAppIcon />
+            </IconButton>
+            <IconButton
+              component={Link}
+              href="https://www.instagram.com/hiddenleeafresort?igsh=MWh1amRlYmE4a3lkdA=="
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open Instagram"
+              sx={Styles.iconButton}
+            >
+              <InstagramIcon />
+            </IconButton>
+            <IconButton
+              component={Link}
+              href="https://www.facebook.com/p/Hidden-Leaf-61556696991093/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open Facebook"
+              sx={Styles.iconButton}
+            >
+              <FacebookIcon />
+            </IconButton>
           </Grid>
         </Box>
         <Box>
           <Grid sx={Styles.addressbox}>
             <Typography sx={Styles.addressHead}>Address</Typography>
-            <Typography sx={Styles.address}>
-              PX67+X5W, Kondhve Khind, At Post - Kondhve, beside Shahupuri
-              Kondhve Road, Satara, Maharashtra 415002
-            </Typography>
+            <Typography sx={Styles.address}>{ADDRESS}</Typography>
+            <Link
+              href={MAP_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={Styles.mapLink}
+            >
+              <LocationOnOutlinedIcon fontSize="small" /> Open on Map
+            </Link>
           </Grid>
         </Box>
       </Box>

--- a/src/Component/Header/Header.js
+++ b/src/Component/Header/Header.js
@@ -6,8 +6,11 @@ import {
   IconButton,
   Box,
   Stack,
+  Link,
 } from "@mui/material";
 import PhoneInTalkRoundedIcon from "@mui/icons-material/PhoneInTalkRounded";
+
+const CONTACT_NUMBER = "+917030092200";
 
 const Styles = {
   headerName: {
@@ -52,10 +55,20 @@ const Header = ({ activeOption, setActiveOption }) => {
         </Box>
         <Box flexGrow={1} />
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.4, sm: 1.1 }}>
-          <IconButton edge="end" color="inherit" sx={{ mr: { xs: 0, sm: 1 } }}>
+          <IconButton
+            edge="end"
+            color="inherit"
+            component={Link}
+            href={`tel:${CONTACT_NUMBER}`}
+            aria-label="Call Hidden Leaf"
+            sx={{ mr: { xs: 0, sm: 1 }, p: { xs: 0.6, sm: 1 } }}
+          >
             <PhoneInTalkRoundedIcon sx={{ fontSize: { xs: 19, sm: 28 } }} />
           </IconButton>
-          {["Menus", "Home"].map((option) => (
+          {[
+            "Menus",
+            "Home",
+          ].map((option) => (
             <Typography
               key={option}
               variant="body1"

--- a/src/Component/Menus/Menus.js
+++ b/src/Component/Menus/Menus.js
@@ -1,7 +1,6 @@
 import { Box, Typography, Grid } from "@mui/material";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import useInView from "../../Component/useInView";
 
 const Styles = {
   imageWrapper: {
@@ -67,11 +66,14 @@ const Styles = {
   },
 };
 
+const itemAnimation = {
+  hidden: { opacity: 0, y: 26 },
+  visible: { opacity: 1, y: 0 },
+};
+
 const Menus = () => {
   const [menu, setMenu] = useState([]);
   const [visibleItems, setVisibleItems] = useState(4);
-  const [setRef1, inView1] = useInView({ threshold: 0.1 });
-  const [setRef2, inView2] = useInView({ threshold: 0.1 });
 
   useEffect(() => {
     const fetchMenus = async () => {
@@ -93,13 +95,14 @@ const Menus = () => {
         Our Highest-Rated Exquisite Menus
       </Typography>
       <Grid container spacing={3}>
-        {menu.slice(0, visibleItems).map((item) => (
+        {menu.slice(0, visibleItems).map((item, index) => (
           <Grid item xs={12} md={6} key={item.id} sx={Styles.itemBox}>
             <motion.div
-              ref={setRef1}
-              initial={{ opacity: 0, y: 50 }}
-              animate={{ opacity: inView1 ? 1 : 0, y: inView1 ? 0 : 50 }}
-              transition={{ duration: 0.5 }}
+              variants={itemAnimation}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.12, margin: "0px 0px -8% 0px" }}
+              transition={{ duration: 0.45, delay: index * 0.04, ease: "easeOut" }}
               style={{ width: "100%" }}
             >
               <Box sx={Styles.imageWrapper}>
@@ -113,10 +116,11 @@ const Menus = () => {
             </motion.div>
             <Box sx={Styles.itemTextBox}>
               <motion.div
-                ref={setRef2}
-                initial={{ opacity: 0, y: 50 }}
-                animate={{ opacity: inView2 ? 1 : 0, y: inView2 ? 0 : 50 }}
-                transition={{ duration: 0.5 }}
+                variants={itemAnimation}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.08, margin: "0px 0px -10% 0px" }}
+                transition={{ duration: 0.45, delay: index * 0.04 + 0.08, ease: "easeOut" }}
               >
                 <Typography sx={Styles.itemName}>{item.name}</Typography>
                 <Typography sx={Styles.itemDesc}>{item.description}</Typography>


### PR DESCRIPTION
### Motivation
- Make the header call icon actionable so users can tap to dial `+91 70300 92200` directly. 
- Replace static image social icons in the footer with working social actions (WhatsApp/Instagram/Facebook) and expose a map action for the resort address. 
- Remove the unused footer quick-links (`Customer reviews`, `Booking Tables`, `Contact Us`) and focus the footer on contact/address. 
- Improve the visibility/reveal behavior of the “Our Highest-Rated Exquisite Menus” section so items appear smoothly on slow mobile scroll. 

### Description
- Header: added a `CONTACT_NUMBER` constant and turned the phone icon into a clickable `Link`/`tel:` action so tapping the icon opens the dialer (`src/Component/Header/Header.js`).
- Footer: removed image-based social icons and the middle quick-links list, added `IconButton` controls for WhatsApp/Instagram/Facebook using the provided URLs, consolidated to a single contact number link, and added an `Open on Map` link pointing to Google Maps (`src/Component/Footer/Footer.js`).
- Menus: replaced the shared `useInView` intersection approach with per-item Framer Motion `whileInView` animations and tuned `viewport`/`margin`/`amount`/`delay` values to make item reveals reliable and smooth during slow mobile scrolling (`src/Component/Menus/Menus.js`).
- Files changed: `src/Component/Header/Header.js`, `src/Component/Footer/Footer.js`, `src/Component/Menus/Menus.js`.

### Testing
- Ran `npm run build` and the production build completed successfully. (Succeeded)
- Started the dev server with `npm start` and verified the app in a mobile viewport; the server started and pages rendered. (Succeeded)
- Captured a mobile viewport screenshot via an automated Playwright script to validate the menu reveal and layout (artifact produced). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f5a3668c832795a0c3f24797b3d8)